### PR TITLE
Fix size mismatch if the prediction is empty

### DIFF
--- a/eval_ssd.py
+++ b/eval_ssd.py
@@ -55,6 +55,10 @@ class MeanAPEvaluator:
             logging.debug(f"evaluating average precision   image {i} / {len(self.dataset)}")
             image = self.dataset.get_image(i)
             boxes, labels, probs = self.predictor.predict(image)
+            if labels.nelement() == 0:
+                boxes = torch.zeros(1, 4, dtype=torch.float32)
+                labels = torch.ones(1, dtype=torch.int64)
+                probs = torch.zeros(1, dtype=torch.float32)
             indexes = torch.ones(labels.size(0), 1, dtype=torch.float32) * i
             results.append(torch.cat([
                 indexes.reshape(-1, 1),


### PR DESCRIPTION
Currently, if the model output empty predictions like `(tensor([]), tensor([]), tensor([]))`, the evaluation script would output errors like 
```bash
Traceback (most recent call last):
  File "eval_ssd.py", line 243, in <module>
    mean_ap, class_ap = eval.compute()
  File "eval_ssd.py", line 66, in compute
    results = torch.cat(results)
RuntimeError: Sizes of tensors must match except in dimension 0. Expected size 7 but got size 3 for tensor number 472 in the list.
```

This fix adds an empty box with probability 0 to fix such errors, which would IMO not affect the final evaluation results. 